### PR TITLE
Fix Staff, footer, Blog, and resource-center cleanup

### DIFF
--- a/teachinghistory-website/content/about/_index.md
+++ b/teachinghistory-website/content/about/_index.md
@@ -2,6 +2,9 @@
 title: "About Us"
 date: 2025-01-20T10:00:00Z
 draft: false
+layout: staff
+aliases:
+  - /about/staff/
 ---
 
 TeachingHistory.org is a comprehensive resource for history educators, providing lesson plans, primary sources, and teaching strategies.

--- a/teachinghistory-website/content/about/staff.md
+++ b/teachinghistory-website/content/about/staff.md
@@ -1,5 +1,0 @@
----
-title: Staff
-layout: staff
-url: /about/staff/
----

--- a/teachinghistory-website/content/blog/_index.md
+++ b/teachinghistory-website/content/blog/_index.md
@@ -1,0 +1,4 @@
+---
+title: Blog
+url: /blog/
+---

--- a/teachinghistory-website/content/national-resource-centers/_index.md
+++ b/teachinghistory-website/content/national-resource-centers/_index.md
@@ -1,0 +1,6 @@
+---
+title: National History Day Resources
+url: /national-resource-centers/
+---
+
+National History Day Resources are currently in development. Check back here soon!

--- a/teachinghistory-website/layouts/_default/list.html
+++ b/teachinghistory-website/layouts/_default/list.html
@@ -10,6 +10,7 @@
 
     <section>
       {{ range .Pages.ByDate.Reverse }}
+        {{ $page := . }}
         <article class="border-b border-gray-light pb-4 mb-4">
           <h2 class="font-heading text-xl mb-1">
             <a href="{{ .Permalink }}" class="hover:underline">{{ .Title }}</a>
@@ -18,7 +19,7 @@
             <time class="text-xs text-gray-400">{{ dateFormat "January 2, 2006" . }}</time>
           {{ end }}
           <p class="text-sm mt-2 text-gray-600 line-clamp-2">
-            {{ with .Params.summary }}{{ . | plainify | truncate 150 }}{{ else }}{{ .Summary | plainify | truncate 150 }}{{ end }}
+            {{ with .Params.summary }}{{ $page.RenderString (dict "display" "inline") . }}{{ else }}{{ .Summary | plainify | truncate 150 }}{{ end }}
           </p>
         </article>
       {{ end }}

--- a/teachinghistory-website/layouts/about/staff.html
+++ b/teachinghistory-website/layouts/about/staff.html
@@ -4,6 +4,12 @@
 <main class="flex-1 bg-pale-blue-tint">
   <div class="max-w-5xl mx-auto px-6 py-10">
 
+    {{ with .Content }}
+    <article class="font-body leading-relaxed mb-12">
+      {{ . }}
+    </article>
+    {{ end }}
+
     {{ range $gi, $group := site.Data.staff.groups }}
     <section class="mb-12">
       <h2 class="font-heading text-xl font-bold uppercase tracking-wide mb-6">{{ $group.name }}</h2>

--- a/teachinghistory-website/layouts/partials/footer.html
+++ b/teachinghistory-website/layouts/partials/footer.html
@@ -5,15 +5,13 @@
     <div class="flex flex-wrap items-center justify-center gap-3">
       <a href="/blog/" class="inline-block rounded-full bg-white text-black text-xs px-4 py-2 hover:bg-gray-light transition">Teaching History Blog</a>
       <a href="/national-resource-centers/" class="inline-block rounded-full bg-white text-black text-xs px-4 py-2 hover:bg-gray-light transition">National History Day Resources</a>
-      {{/* TODO: Confirm correct link for Featured Activity */}}
-      <a href="#" class="inline-block rounded-full bg-white text-black text-xs px-4 py-2 hover:bg-gray-light transition">Featured Activity</a>
     </div>
   </div>
 </div>
 
-{{/* Main footer — white background, 5-column grid */}}
+{{/* Main footer — white background, 4-column grid */}}
 <footer class="bg-white border-t border-gray-light mt-auto">
-  <div class="max-w-7xl mx-auto px-6 py-10 grid grid-cols-1 md:grid-cols-5 gap-8 text-xs text-gray-600">
+  <div class="max-w-7xl mx-auto px-6 py-10 grid grid-cols-1 md:grid-cols-4 gap-8 text-xs text-gray-600">
 
     {{/* Col 1: Logos */}}
     <div class="flex flex-col gap-4">
@@ -26,23 +24,13 @@
       </a>
     </div>
 
-    {{/* Col 2: Site links */}}
-    <nav aria-label="Footer links">
-      <ul class="space-y-0">
-        <li class="py-2 border-b border-gray-light"><a href="/about/staff/" class="hover:underline">Staff</a></li>
-        <li class="py-2 border-b border-gray-light"><a href="/about/#partners" class="hover:underline">Project Partners</a></li>
-        <li class="py-2 border-b border-gray-light"><a href="/about/#technical" class="hover:underline">Technical Working Group</a></li>
-        <li class="py-2"><a href="/about/#advisors" class="hover:underline">Research Advisors</a></li>
-      </ul>
-    </nav>
-
-    {{/* Col 3: Disclaimer */}}
+    {{/* Col 2: Disclaimer */}}
     <p class="leading-relaxed">The content of this website does not necessarily reflect the views or policies of the U.S. Department of Education nor does mention of trade names, commercial products, or organizations imply endorsement by the U.S. Government.</p>
 
-    {{/* Col 4: Copyright */}}
+    {{/* Col 3: Copyright */}}
     <p class="leading-relaxed">&copy;2008&mdash;{{ now.Year }} Created by the Roy Rosenzweig Center for History and New Media at George Mason University with funding from the U.S. Department of Education (Contract Number ED-07-CO-0088)</p>
 
-    {{/* Col 5: Creative Commons */}}
+    {{/* Col 4: Creative Commons */}}
     <p class="leading-relaxed">Except where otherwise noted, the content on this site is licensed under a <a href="https://creativecommons.org/licenses/by-nc-sa/3.0/" class="underline hover:text-black">Creative Commons Attribution Non-Commercial Share Alike 3.0 License</a>.</p>
   </div>
 


### PR DESCRIPTION
## Summary

- move the Staff directory to /about/ while preserving /about/staff/ as an alias
- simplify the shared footer and remove obsolete links and Featured Activity
- add the Blog section index and National History Day Resources placeholder
- render inline Markdown correctly in list-page summaries

## Verification

- just check
- just build
- responsive browser checks for About, Blog, National History Day Resources, and the shared footer

Closes #22