### PR TITLE
Fix responsive breakpoints site-wide

### DIFF
--- a/teachinghistory-website/layouts/_default/grade-level.html
+++ b/teachinghistory-website/layouts/_default/grade-level.html
@@ -39,10 +39,10 @@
   {{ if $heroPool }}
     {{ $picked := index ($heroPool | shuffle) 0 }}
     <section class="bg-white">
-      <div class="max-w-7xl mx-auto flex flex-col md:flex-row md:min-h-[320px]">
+      <div class="max-w-7xl mx-auto flex flex-col lg:flex-row lg:min-h-[320px]">
 
         {{/* Left — Teacher's Pick card */}}
-        <div class="w-full md:w-1/2 flex flex-col justify-center px-6 py-8 md:px-10 md:py-10">
+        <div class="w-full lg:w-1/2 flex flex-col justify-center px-6 py-8 sm:px-8 sm:py-10 md:px-10">
           <p class="font-heading text-xs uppercase tracking-widest mb-3">Teacher's Pick</p>
           <h2 class="font-heading text-3xl leading-tight mb-4 normal-case">{{ $picked.Title }}</h2>
           <p class="font-body text-sm leading-relaxed mb-6">
@@ -52,10 +52,10 @@
         </div>
 
         {{/* Right — splash image */}}
-        <div class="w-full md:w-1/2">
+        <div class="w-full lg:w-1/2">
           <img src="{{ $picked.Params.splash_image }}"
                alt="{{ $picked.Title }}"
-               class="w-full h-full object-cover">
+               class="w-full h-56 sm:h-72 md:h-80 lg:h-full object-cover">
         </div>
 
       </div>

--- a/teachinghistory-website/layouts/_default/section-index.html
+++ b/teachinghistory-website/layouts/_default/section-index.html
@@ -10,7 +10,7 @@
 
 {{ $tint := partial "section-tint.html" .Section }}
 <main class="flex-1 {{ $tint }}">
-  <div class="max-w-7xl mx-auto px-4 md:px-6 py-6 md:py-10">
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 md:px-8 lg:px-6 py-6 sm:py-8 lg:py-10">
     {{ range .Sections.ByWeight }}
       {{ partial "horizontal-carousel.html" (dict
           "id"          .File.ContentBaseName

--- a/teachinghistory-website/layouts/_default/single.html
+++ b/teachinghistory-website/layouts/_default/single.html
@@ -5,13 +5,13 @@
 {{ partial "page-hero.html" (dict "title" $sectionTitle "color" $color) }}
 
 <main class="flex-1">
-  <div class="flex flex-col md:flex-row min-h-[60vh]">
+  <div class="flex flex-col lg:flex-row min-h-[60vh]">
     {{/* Left column — 1/3, section tint background (hidden on mobile for default template) */}}
-    <aside class="{{ $tint }} hidden md:block md:w-1/3 p-8">
+    <aside class="{{ $tint }} hidden lg:block lg:w-1/3 p-8">
     </aside>
 
     {{/* Right column — 2/3, white background */}}
-    <div class="w-full md:w-2/3 bg-white p-6 md:p-8">
+    <div class="w-full lg:w-2/3 bg-white p-6 md:p-8">
       <article>
         <h2 class="font-heading text-2xl mb-4 normal-case">{{ .Title }}</h2>
 

--- a/teachinghistory-website/layouts/_default/sitemap.html
+++ b/teachinghistory-website/layouts/_default/sitemap.html
@@ -24,7 +24,7 @@
 
 {{/* Stats bar */}}
 <section class="max-w-6xl mx-auto px-4 py-8">
-  <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+  <div class="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
     <div class="bg-gray-50 rounded-lg p-4 text-center">
       <div class="text-3xl font-heading font-bold text-black">{{ $totalPages }}</div>
       <div class="text-sm text-gray-600 mt-1">Total Pages</div>

--- a/teachinghistory-website/layouts/about/staff.html
+++ b/teachinghistory-website/layouts/about/staff.html
@@ -14,7 +14,7 @@
     <section class="mb-12">
       <h2 class="font-heading text-xl font-bold uppercase tracking-wide mb-6">{{ $group.name }}</h2>
 
-      <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
         {{ range $mi, $member := $group.members }}
         {{ $id := printf "staff-%d-%d" $gi $mi }}
         <div class="bg-white rounded shadow-md p-6">

--- a/teachinghistory-website/layouts/best-practices/single.html
+++ b/teachinghistory-website/layouts/best-practices/single.html
@@ -4,10 +4,10 @@
 {{ partial "page-hero.html" (dict "title" "Best Practices" "color" $color) }}
 
 <main class="flex-1">
-  <div class="flex flex-col md:flex-row">
+  <div class="flex flex-col lg:flex-row">
     {{/* Left column — 1/3, section tint background */}}
-    <aside class="{{ $tint }} w-full md:w-1/3 p-6 md:p-8">
-      <div class="md:sticky md:top-[76px] flex flex-col gap-6">
+    <aside class="{{ $tint }} w-full lg:w-1/3 p-6 md:p-8">
+      <div class="lg:sticky lg:top-[76px] flex flex-col gap-6">
 
       {{/* Subsection header + View all link */}}
       <div>
@@ -61,7 +61,7 @@
     </aside>
 
     {{/* Right column — 2/3, white background */}}
-    <div class="w-full md:w-2/3 bg-white p-6 md:p-8">
+    <div class="w-full lg:w-2/3 bg-white p-6 md:p-8">
       <article>
         <h2 class="font-heading text-2xl mb-4 normal-case">{{ .Title }}</h2>
 

--- a/teachinghistory-website/layouts/digital-classroom/section-index.html
+++ b/teachinghistory-website/layouts/digital-classroom/section-index.html
@@ -10,7 +10,7 @@
 
 {{ $tint := partial "section-tint.html" .Section }}
 <main class="flex-1 {{ $tint }}">
-  <div class="max-w-7xl mx-auto px-4 md:px-6 py-6 md:py-10">
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 md:px-8 lg:px-6 py-6 sm:py-8 lg:py-10">
     {{ range .Sections.ByWeight }}
       {{ if not (eq .File.ContentBaseName "ask-a-digital-historian") }}
         {{ partial "horizontal-carousel.html" (dict

--- a/teachinghistory-website/layouts/digital-classroom/single.html
+++ b/teachinghistory-website/layouts/digital-classroom/single.html
@@ -10,10 +10,10 @@
 {{ partial "page-hero.html" (dict "title" "Digital Classroom" "color" $color) }}
 
 <main class="flex-1">
-  <div class="flex flex-col md:flex-row">
+  <div class="flex flex-col lg:flex-row">
     {{/* Left column — 1/3, section tint background */}}
-    <aside class="{{ $tint }} w-full md:w-1/3 p-6 md:p-8">
-      <div class="md:sticky md:top-[76px] flex flex-col gap-6">
+    <aside class="{{ $tint }} w-full lg:w-1/3 p-6 md:p-8">
+      <div class="lg:sticky lg:top-[76px] flex flex-col gap-6">
 
       {{/* Subsection header + View all link */}}
       <div>
@@ -71,7 +71,7 @@
     </aside>
 
     {{/* Right column — 2/3, white background */}}
-    <div class="w-full md:w-2/3 bg-white p-6 md:p-8">
+    <div class="w-full lg:w-2/3 bg-white p-6 md:p-8">
       <article>
         <h2 class="font-heading text-2xl mb-2 normal-case">{{ .Title }}</h2>
 
@@ -105,9 +105,9 @@
         {{ with $related }}
         <section class="mt-10 pt-6 border-t border-gray-light">
           <h3 class="font-heading text-lg font-bold uppercase mb-4">Related Topics</h3>
-          <div class="flex gap-4">
+          <div class="flex flex-col sm:flex-row gap-4">
             {{ range . }}
-              {{ partial "content-card.html" (dict "page" . "width" "w-1/2") }}
+              {{ partial "content-card.html" (dict "page" . "width" "w-full sm:w-1/2") }}
             {{ end }}
           </div>
         </section>

--- a/teachinghistory-website/layouts/history-content/single.html
+++ b/teachinghistory-website/layouts/history-content/single.html
@@ -4,10 +4,10 @@
 {{ partial "page-hero.html" (dict "title" "History Content" "color" $color) }}
 
 <main class="flex-1">
-  <div class="flex flex-col md:flex-row">
+  <div class="flex flex-col lg:flex-row">
     {{/* Left column — 1/3, section tint background */}}
-    <aside class="{{ $tint }} w-full md:w-1/3 p-6 md:p-8">
-      <div class="md:sticky md:top-[76px] flex flex-col gap-6">
+    <aside class="{{ $tint }} w-full lg:w-1/3 p-6 md:p-8">
+      <div class="lg:sticky lg:top-[76px] flex flex-col gap-6">
 
       {{/* Subsection header + View all link */}}
       <div>
@@ -102,7 +102,7 @@
     </aside>
 
     {{/* Right column — 2/3, white background */}}
-    <div class="w-full md:w-2/3 bg-white p-6 md:p-8">
+    <div class="w-full lg:w-2/3 bg-white p-6 md:p-8">
       <article>
         <h2 class="font-heading text-2xl mb-2 normal-case">{{ .Title }}</h2>
 

--- a/teachinghistory-website/layouts/index.html
+++ b/teachinghistory-website/layouts/index.html
@@ -3,22 +3,22 @@
 
   {{/* ── Hero Section ── */}}
   <section class="bg-white">
-    <div class="max-w-7xl mx-auto flex flex-col md:flex-row md:min-h-[420px]">
+    <div class="max-w-7xl mx-auto flex flex-col lg:flex-row lg:min-h-[420px]">
 
       {{/* Left column — 1/3: headline pinned to bottom */}}
-      <div class="md:w-1/3 flex flex-col justify-end px-6 py-8 md:px-10 md:py-12 shadow-[4px_4px_12px_rgba(0,0,0,0.15)]">
+      <div class="lg:w-1/3 flex flex-col justify-end px-6 py-8 sm:px-8 sm:py-10 lg:px-10 lg:py-12 shadow-[4px_4px_12px_rgba(0,0,0,0.15)]">
         <h1 class="font-heading text-2xl md:text-3xl leading-tight mb-4">Explore Our Resources and Materials</h1>
         <a href="/teaching-materials/" class="text-orange text-xl">&rarr;</a>
       </div>
 
       {{/* Right column — 2/3: pale-blue tint with staggered cards */}}
-      <div class="md:w-2/3 bg-pale-blue flex items-center justify-center px-4 py-8 md:px-8 md:py-10">
-        <div class="flex gap-4 md:gap-6 items-center overflow-x-auto md:overflow-x-visible">
+      <div class="lg:w-2/3 bg-pale-blue flex items-center justify-center px-4 py-8 sm:px-6 sm:py-10 md:px-8 lg:py-10">
+        <div class="flex gap-4 lg:gap-6 items-center overflow-x-auto sm:justify-center lg:overflow-x-visible">
 
           {{ $sections := slice
-            (dict "name" "Teaching Materials" "key" "teaching-materials" "color" "orange" "offset" "md:translate-y-10")
-            (dict "name" "History Content"    "key" "history-content"    "color" "yellow" "offset" "md:translate-y-0")
-            (dict "name" "Best Practices"     "key" "best-practices"    "color" "green"  "offset" "md:-translate-y-10")
+            (dict "name" "Teaching Materials" "key" "teaching-materials" "color" "orange" "offset" "lg:translate-y-10")
+            (dict "name" "History Content"    "key" "history-content"    "color" "yellow" "offset" "lg:translate-y-0")
+            (dict "name" "Best Practices"     "key" "best-practices"    "color" "green"  "offset" "lg:-translate-y-10")
           }}
 
           {{/* Build a JSON pool of candidates per section for client-side randomization */}}
@@ -61,7 +61,7 @@
             {{/* Render card with first item as default (works without JS) */}}
             {{ $picked := index $pool 0 }}
 
-            <div class="w-40 md:w-52 shrink-0 flex flex-col rounded overflow-hidden shadow-md transform {{ $offset }}"
+            <div class="w-40 sm:w-44 lg:w-52 shrink-0 flex flex-col rounded overflow-hidden shadow-md transform {{ $offset }}"
                  data-hero-card>
               {{/* Section title bar — white */}}
               <div class="bg-white px-3 py-2">
@@ -119,11 +119,11 @@
   {{ end }}
   {{ $images = $images | first 20 }}
 
-  <section class="bg-white px-4 py-8 md:px-12 md:py-14">
-    <div class="max-w-7xl mx-auto flex flex-col md:flex-row md:min-h-[380px] bg-black overflow-hidden">
+  <section class="bg-white px-4 py-8 sm:px-6 sm:py-10 md:px-8 md:py-12 lg:px-12 lg:py-14">
+    <div class="max-w-7xl mx-auto flex flex-col lg:flex-row lg:min-h-[380px] bg-black overflow-hidden">
 
       {{/* Left column — rotating splash images */}}
-      <div class="h-[200px] md:h-auto md:w-1/2 relative overflow-hidden"
+      <div class="h-[200px] sm:h-[260px] md:h-[320px] lg:h-auto lg:w-1/2 relative overflow-hidden"
            x-data="{
              images: {{ $images | jsonify }},
              current: 0,
@@ -142,7 +142,7 @@
       </div>
 
       {{/* Right column — text + video pill */}}
-      <div class="md:w-1/2 flex flex-col justify-center px-6 py-8 md:px-12 md:py-12">
+      <div class="lg:w-1/2 flex flex-col justify-center px-6 py-8 sm:px-8 sm:py-10 md:px-10 lg:px-12 lg:py-12">
         <h2 class="font-heading text-2xl md:text-3xl text-yellow mb-4 normal-case">Think historically</h2>
         <p class="font-body text-sm text-white leading-relaxed mb-6">
           Teachinghistory.org is designed to help K–12 history teachers access resources
@@ -171,11 +171,11 @@
     {{ end }}
   {{ end }}
 
-  <section class="bg-white px-4 py-8 md:px-12 md:py-14">
-    <div class="max-w-7xl mx-auto px-2 md:px-6">
+  <section class="bg-white px-4 py-8 sm:px-6 sm:py-10 md:px-8 md:py-12 lg:px-12 lg:py-14">
+    <div class="max-w-7xl mx-auto px-2 sm:px-4 lg:px-6">
       <h2 class="font-heading text-2xl text-center mb-8 normal-case">Explore by Grade Level</h2>
 
-      <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
         {{ $grades := slice
           (dict "label" "Elementary School Teachers" "url" "/elementary-quick-links/")
           (dict "label" "Middle School Teachers"     "url" "/middle-quick-links/")

--- a/teachinghistory-website/layouts/partials/arrow-button.html
+++ b/teachinghistory-website/layouts/partials/arrow-button.html
@@ -28,6 +28,6 @@
 {{ end }}
 
 <a href="{{ $href }}"
-   class="inline-flex items-center gap-1.5 {{ $bgClass }} {{ $hoverClass }} text-white text-sm font-body px-5 py-2 rounded-full transition">
+   class="inline-flex self-start items-center gap-1.5 {{ $bgClass }} {{ $hoverClass }} text-white text-sm font-body px-5 py-2 rounded-full transition">
   {{- $text }} &rarr;
 </a>

--- a/teachinghistory-website/layouts/partials/footer.html
+++ b/teachinghistory-website/layouts/partials/footer.html
@@ -11,7 +11,7 @@
 
 {{/* Main footer — white background, 4-column grid */}}
 <footer class="bg-white border-t border-gray-light mt-auto">
-  <div class="max-w-7xl mx-auto px-6 py-10 grid grid-cols-1 md:grid-cols-4 gap-8 text-xs text-gray-600">
+  <div class="max-w-7xl mx-auto px-6 py-10 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8 text-xs text-gray-600">
 
     {{/* Col 1: Logos */}}
     <div class="flex flex-col gap-4">

--- a/teachinghistory-website/layouts/partials/horizontal-carousel.html
+++ b/teachinghistory-website/layouts/partials/horizontal-carousel.html
@@ -27,9 +27,9 @@
 {{ $color := .color | default "orange" }}
 {{ $pages := .pages }}
 
-<div class="flex flex-col md:flex-row gap-4 md:gap-8 py-6 md:py-8">
+<div class="flex flex-col lg:flex-row gap-4 lg:gap-8 py-6 md:py-8">
   {{/* Left column — label + description + View All */}}
-  <div class="md:w-[200px] md:shrink-0 flex flex-col">
+  <div class="lg:w-[200px] lg:shrink-0 flex flex-col">
     <h2 class="font-heading text-xl font-bold mb-2">{{ $heading }}</h2>
     <p class="font-body text-xs text-gray-600 leading-relaxed mb-4">{{ $description }}</p>
     {{ partial "arrow-button.html" (dict "text" "View All" "href" $viewAllURL "color" $color) }}
@@ -38,14 +38,14 @@
   {{/* Right column — scrollable card row + arrows */}}
   <div class="flex-1 min-w-0">
     {{/* Scrollable card container */}}
-    <div id="carousel-{{ $id }}" class="flex gap-4 overflow-x-auto md:overflow-x-hidden scroll-smooth -mx-4 px-4 md:mx-0 md:px-0">
+    <div id="carousel-{{ $id }}" class="flex gap-4 overflow-x-auto lg:overflow-x-hidden scroll-smooth -mx-4 px-4 lg:mx-0 lg:px-0">
       {{ range $pages }}
         {{ partial "content-card.html" (dict "page" .) }}
       {{ end }}
     </div>
 
     {{/* Arrow navigation — hidden on mobile where swipe works */}}
-    <div class="hidden md:flex gap-2 mt-3">
+    <div class="hidden lg:flex gap-2 mt-3">
       <button
         type="button"
         aria-label="Scroll left"

--- a/teachinghistory-website/layouts/partials/navbar.html
+++ b/teachinghistory-website/layouts/partials/navbar.html
@@ -20,7 +20,7 @@
   {{ $currentSection = "digital-classroom" }}
 {{ end }}
 
-<nav class="h-[60px] fixed top-0 left-0 right-0 z-50 bg-white border-b border-gray-light shadow-md flex items-center px-4 md:px-6"
+<nav class="h-[60px] fixed top-0 left-0 right-0 z-50 bg-white border-b border-gray-light shadow-md flex items-center px-4 sm:px-6 lg:px-8"
      aria-label="Main navigation"
      x-data="{ open: false }">
   <div class="flex items-center justify-between w-full max-w-7xl mx-auto">
@@ -29,7 +29,7 @@
     </a>
 
     {{/* Desktop nav links */}}
-    <div class="hidden md:flex items-center font-body text-sm">
+    <div class="hidden lg:flex items-center font-body text-sm">
       {{ range .Site.Menus.main }}
         {{ $isActive := eq .Identifier $currentSection }}
 
@@ -46,7 +46,7 @@
     </div>
 
     {{/* Mobile hamburger button */}}
-    <button class="md:hidden flex items-center justify-center w-10 h-10"
+    <button class="lg:hidden flex items-center justify-center w-10 h-10"
             @click="open = !open"
             :aria-expanded="open"
             aria-label="Toggle navigation menu">
@@ -68,7 +68,7 @@
        x-transition:leave="transition ease-in duration-150"
        x-transition:leave-start="opacity-100 translate-y-0"
        x-transition:leave-end="opacity-0 -translate-y-2"
-       class="md:hidden absolute top-[60px] left-0 right-0 bg-white border-b border-gray-light shadow-lg">
+       class="lg:hidden absolute top-[60px] left-0 right-0 bg-white border-b border-gray-light shadow-lg">
     <div class="flex flex-col font-body text-sm py-2">
       {{ range .Site.Menus.main }}
         {{ $isActive := eq .Identifier $currentSection }}

--- a/teachinghistory-website/layouts/partials/related-materials.html
+++ b/teachinghistory-website/layouts/partials/related-materials.html
@@ -11,7 +11,7 @@
 {{- with $related }}
 <section class="mt-10 pt-6 border-t border-gray-light">
   <h2 class="font-heading text-xl font-bold uppercase mb-4">Related Materials</h2>
-  <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
     {{ range . }}
       {{ partial "content-card.html" (dict "page" . "width" "w-full") }}
     {{ end }}

--- a/teachinghistory-website/layouts/partials/subsection-list.html
+++ b/teachinghistory-website/layouts/partials/subsection-list.html
@@ -26,11 +26,11 @@
 {{ $pages := $ctx.RegularPages }}
 
 <main class="flex-1">
-  <div class="flex flex-col md:flex-row min-h-screen">
+  <div class="flex flex-col lg:flex-row min-h-screen">
 
     {{/* ── Left column — 1/3, section tint ── */}}
-    <aside class="{{ $tint }} w-full md:w-1/3 p-6 md:p-8">
-      <div class="md:sticky md:top-[76px] flex flex-col gap-6">
+    <aside class="{{ $tint }} w-full lg:w-1/3 p-6 md:p-8">
+      <div class="lg:sticky lg:top-[76px] flex flex-col gap-6">
 
         {{/* Section header + View all link */}}
         <div>
@@ -48,7 +48,7 @@
     </aside>
 
     {{/* ── Right column — 2/3, white background, card grid ── */}}
-    <div class="w-full md:w-2/3 bg-white p-6 md:p-8">
+    <div class="w-full lg:w-2/3 bg-white p-6 md:p-8">
       <h2 class="font-heading text-2xl mb-2 normal-case">{{ $ctx.Title }}</h2>
       {{ with $ctx.Params.description }}
         <p class="font-body text-sm text-gray-600 mb-6">{{ . }}</p>

--- a/teachinghistory-website/layouts/teaching-materials/single.html
+++ b/teachinghistory-website/layouts/teaching-materials/single.html
@@ -4,10 +4,10 @@
 {{ partial "page-hero.html" (dict "title" "Teaching Materials" "color" $color) }}
 
 <main class="flex-1">
-  <div class="flex flex-col md:flex-row">
+  <div class="flex flex-col lg:flex-row">
     {{/* Left column — 1/3, section tint background */}}
-    <aside class="{{ $tint }} w-full md:w-1/3 p-6 md:p-8">
-      <div class="md:sticky md:top-[76px] flex flex-col gap-6">
+    <aside class="{{ $tint }} w-full lg:w-1/3 p-6 md:p-8">
+      <div class="lg:sticky lg:top-[76px] flex flex-col gap-6">
 
       {{/* Subsection header + View all link */}}
       <div>
@@ -142,7 +142,7 @@
     </aside>
 
     {{/* Right column — 2/3, white background */}}
-    <div class="w-full md:w-2/3 bg-white p-6 md:p-8">
+    <div class="w-full lg:w-2/3 bg-white p-6 md:p-8">
       <article>
         <h2 class="font-heading text-2xl mb-2 normal-case">{{ .Title }}</h2>
 

--- a/teachinghistory-website/tailwind.config.js
+++ b/teachinghistory-website/tailwind.config.js
@@ -1,6 +1,8 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: ["./layouts/**/*.html", "./content/**/*.md"],
+  // Four layout bands use Tailwind's defaults: mobile base, sm, md, and lg.
+  // xl and 2xl remain available for isolated wide-screen refinements.
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
## Summary

- establish four site-wide responsive layout bands using Tailwind's mobile base, `sm`, `md`, and `lg` breakpoints
- keep sidebars stacked and carousels swipeable through tablet widths, with denser desktop layouts beginning at `lg`
- update the homepage, navigation, footer, content templates, staff grid, grade-level pages, and shared components consistently

## Why

Tablet layouts were adopting desktop structures too early, which compressed sidebars, cards, navigation, and carousel content. The shared breakpoint convention now gives mobile, small-screen, tablet, and desktop viewports predictable behavior across templates.

## Validation

- `just check` — production Hugo build completed successfully with 8,347 pages
- `just css` — production Tailwind build completed successfully
- visually checked representative pages at 375, 640, 768, 1024, and 1440 pixels with no page-level horizontal overflow

Closes #15
