### PR TITLE
Add site-wide Pagefind search

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -204,6 +204,24 @@ Lets teachers find specific resources within a subsection using keyword search a
 
 ---
 
+### Feature: Site-wide Search
+
+**Description:**
+A dedicated search page that indexes published site content at build time with Pagefind.
+
+**User Value:**
+Lets teachers find resources across content sections without knowing where a page lives in the site hierarchy.
+
+**Functionality:**
+- `/search/` page linked from the primary navigation
+- Full-text client-side search backed by a static Pagefind index
+- Content-area filter for Teaching Materials, History Content, Best Practices, Digital Classroom, and other site content
+- Accessible keyboard navigation, result counts, excerpts, highlighted matches, and no-results feedback
+- Responsive single-column layout through tablet widths and filter/results columns on desktop
+- Search index generated after Hugo in local and Docker production builds
+
+---
+
 ### Feature: About Us / Staff Grid
 
 **Description:**
@@ -262,7 +280,6 @@ Team page showing staff members with a bio modal.
 
 ### Explicitly Excluded
 - **Ask a Historian feature** — removed from this rebuild
-- **Site-wide search** — subsection-level keyword filtering exists; full-text site-wide search not planned for V1
 - **User authentication / accounts** — site is fully public, no login
 - **CMS admin interface** — content managed as Markdown files in the repository
 - **Faceted search** on section index pages (subsection list pages have basic keyword/dropdown filtering)
@@ -274,7 +291,6 @@ Team page showing staff members with a bio modal.
 - **Responsive / mobile design** — not explicitly specified in Figma; inferred breakpoints to be confirmed with design team
 
 ### Future Considerations
-- Full-text search across all content
 - Interactive quiz functionality (currently static content)
 - RSS feeds for blog/new content
 

--- a/justfile
+++ b/justfile
@@ -13,7 +13,7 @@ serve:
 
 # Build the site for production
 build:
-    cd {{site}} && hugo --minify
+    cd {{site}} && npm run build
 
 # Build the site including drafts
 build-drafts:
@@ -23,6 +23,10 @@ build-drafts:
 css:
     rm -rf {{site}}/resources/_gen
     cd {{site}} && hugo --minify
+
+# Generate the Pagefind index from an existing production build
+search:
+    cd {{site}} && npm run build:search
 
 # Clean generated files
 clean:

--- a/teachinghistory-website/Dockerfile
+++ b/teachinghistory-website/Dockerfile
@@ -16,6 +16,7 @@ COPY . .
 
 RUN npm ci
 RUN hugo ${HUGO_BUILD_ARGS}
+RUN npm run build:search
 
 FROM stagex/user-caddy
 

--- a/teachinghistory-website/content/_index.md
+++ b/teachinghistory-website/content/_index.md
@@ -23,7 +23,7 @@ draft: false
 - [ ] Verify navigation menus are complete
 
 **Functionality**
-- [ ] Test search functionality (eventually...)
+- [x] Test site-wide search functionality
 - [ ] Verify any forms are working
 - [ ] Check RSS feeds are generating correctly
 - [ ] Test 404 error page

--- a/teachinghistory-website/content/search.md
+++ b/teachinghistory-website/content/search.md
@@ -1,0 +1,5 @@
+---
+title: "Search"
+layout: "search"
+summary: "Search TeachingHistory.org resources, articles, teaching materials, and classroom guidance."
+---

--- a/teachinghistory-website/hugo.toml
+++ b/teachinghistory-website/hugo.toml
@@ -84,6 +84,12 @@ disableAliases = true
     url = '/digital-classroom/'
     weight = 50
 
+  [[menu.main]]
+    identifier = 'search'
+    name = 'Search'
+    url = '/search/'
+    weight = 60
+
 # Redirect manifest — the deterministic legacy->native bridge for the Caddy
 # redirect pipeline (utils/redirect_mapper.py). The home page emits
 # /redirects.json listing every page's native URL and its legacy paths.

--- a/teachinghistory-website/layouts/_default/baseof.html
+++ b/teachinghistory-website/layouts/_default/baseof.html
@@ -1,6 +1,18 @@
 <!DOCTYPE html>
 <html lang="{{ .Site.LanguageCode | default "en" }}">
 <head>
+  {{/* Pagefind content-area facet. Search and error pages are excluded below. */}}
+  {{ $searchSection := "More from TeachingHistory.org" }}
+  {{ if eq .Section "teaching-materials" }}
+    {{ $searchSection = "Teaching Materials" }}
+  {{ else if eq .Section "history-content" }}
+    {{ $searchSection = "History Content" }}
+  {{ else if eq .Section "best-practices" }}
+    {{ $searchSection = "Best Practices" }}
+  {{ else if eq .Section "digital-classroom" }}
+    {{ $searchSection = "Digital Classroom" }}
+  {{ end }}
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{{ if not .IsHome }}{{ .Title }} | {{ end }}{{ .Site.Title }}</title>
@@ -33,8 +45,15 @@
       image.src = '/images/th_logo_stacked.png';
     }, true);
   </script>
+
+  {{ block "head" . }}{{ end }}
 </head>
-<body class="min-h-screen flex flex-col font-body text-black bg-white">
+<body
+  class="min-h-screen flex flex-col font-body text-black bg-white"
+  {{ if and (ne .Layout "search") (ne .Kind "404") }}
+    data-pagefind-body
+    data-pagefind-filter="section:{{ $searchSection }}"
+  {{ end }}>
 
   {{ partial "navbar.html" . }}
 

--- a/teachinghistory-website/layouts/_default/search.html
+++ b/teachinghistory-website/layouts/_default/search.html
@@ -1,0 +1,51 @@
+{{ define "head" }}
+  <link href="/pagefind/pagefind-component-ui.css" rel="stylesheet">
+  <script src="/pagefind/pagefind-component-ui.js" type="module"></script>
+{{ end }}
+
+{{ define "main" }}
+{{ partial "page-hero.html" (dict "title" .Title "color" "pale-blue") }}
+
+<main class="flex-1 bg-pale-blue-tint" data-pagefind-ignore>
+  <section class="max-w-6xl mx-auto px-4 sm:px-6 py-8 sm:py-10 lg:py-12">
+    <div class="max-w-3xl mb-8">
+      <h2 class="font-heading text-2xl sm:text-3xl font-bold mb-3">Find resources across the site</h2>
+      <p class="text-sm sm:text-base text-gray-600 leading-relaxed mb-0">
+        Search articles, lesson materials, historical content, classroom practices, and digital teaching resources. Use the content-area filter to narrow your results.
+      </p>
+    </div>
+
+    <div
+      class="grid grid-cols-1 lg:grid-cols-4 gap-6 lg:gap-8 items-start"
+      style="--pf-font: var(--font-body); --pf-text: var(--color-black); --pf-text-secondary: var(--color-dark); --pf-text-muted: var(--color-dark); --pf-background: var(--color-white); --pf-border: var(--color-gray-light); --pf-border-focus: var(--color-orange); --pf-hover: var(--color-orange-tint); --pf-mark: var(--color-orange); --pf-outline-focus: var(--color-orange); --pf-input-height: 3rem; --pf-input-font-size: 1rem; --pf-result-title-font-size: 1.125rem; --pf-result-excerpt-font-size: 0.875rem; --pf-border-radius: 0.5rem; --pf-results-gap: 1rem;">
+      <pagefind-config bundle-path="/pagefind/" excerpt-length="28"></pagefind-config>
+
+      <aside class="lg:col-span-1 bg-white border border-gray-light rounded-lg p-5 lg:sticky lg:top-[84px]">
+        <h3 class="font-heading text-lg font-bold uppercase mb-2">Filter results</h3>
+        <p class="text-xs text-gray-600 leading-relaxed mb-4">Enter a search term, then choose a content area to narrow the results.</p>
+        <pagefind-filter-dropdown
+          filter="section"
+          label="Content area"
+          single-select
+          sort="alphabetical">
+        </pagefind-filter-dropdown>
+      </aside>
+
+      <div class="lg:col-span-3 min-w-0 bg-white border border-gray-light rounded-lg p-4 sm:p-6">
+        <pagefind-input placeholder="Search TeachingHistory.org..."></pagefind-input>
+
+        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 mt-4 mb-3 border-b border-gray-light pb-4">
+          <pagefind-summary default-message="Enter a term to search across the site."></pagefind-summary>
+          <pagefind-keyboard-hints></pagefind-keyboard-hints>
+        </div>
+
+        <pagefind-results max-sub-results="3"></pagefind-results>
+
+        <noscript>
+          <p class="text-sm text-gray-600">Site search requires JavaScript. You can still browse resources from the main navigation.</p>
+        </noscript>
+      </div>
+    </div>
+  </section>
+</main>
+{{ end }}

--- a/teachinghistory-website/layouts/partials/footer.html
+++ b/teachinghistory-website/layouts/partials/footer.html
@@ -1,5 +1,5 @@
 {{/* Quick Links bar — black background */}}
-<div class="bg-black">
+<div class="bg-black" data-pagefind-ignore>
   <div class="max-w-7xl mx-auto px-6 py-4 flex flex-col sm:flex-row items-center justify-center gap-3 sm:gap-4">
     <span class="font-heading text-yellow text-lg">Quick Links &rarr;</span>
     <div class="flex flex-wrap items-center justify-center gap-3">
@@ -10,7 +10,7 @@
 </div>
 
 {{/* Main footer — white background, 4-column grid */}}
-<footer class="bg-white border-t border-gray-light mt-auto">
+<footer class="bg-white border-t border-gray-light mt-auto" data-pagefind-ignore>
   <div class="max-w-7xl mx-auto px-6 py-10 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8 text-xs text-gray-600">
 
     {{/* Col 1: Logos */}}

--- a/teachinghistory-website/layouts/partials/navbar.html
+++ b/teachinghistory-website/layouts/partials/navbar.html
@@ -18,10 +18,13 @@
   {{ $currentSection = "about" }}
 {{ else if hasPrefix $url "/digital-classroom/" }}
   {{ $currentSection = "digital-classroom" }}
+{{ else if hasPrefix $url "/search/" }}
+  {{ $currentSection = "search" }}
 {{ end }}
 
 <nav class="h-[60px] fixed top-0 left-0 right-0 z-50 bg-white border-b border-gray-light shadow-md flex items-center px-4 sm:px-6 lg:px-8"
      aria-label="Main navigation"
+     data-pagefind-ignore
      x-data="{ open: false }">
   <div class="flex items-center justify-between w-full max-w-7xl mx-auto">
     <a href="/" class="flex items-center shrink-0">
@@ -39,7 +42,7 @@
           {{- .Name -}}
         </a>
 
-        {{ if not (eq .Identifier "digital-classroom") }}
+        {{ if not (eq .Identifier "search") }}
           <span class="text-gray-light select-none" aria-hidden="true">|</span>
         {{ end }}
       {{ end }}

--- a/teachinghistory-website/package-lock.json
+++ b/teachinghistory-website/package-lock.json
@@ -7,6 +7,7 @@
       "name": "teachinghistory-website",
       "devDependencies": {
         "autoprefixer": "^10.4",
+        "pagefind": "^1.5.2",
         "postcss": "^8.4",
         "postcss-cli": "^11.0",
         "tailwindcss": "^3.4"
@@ -93,6 +94,97 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@pagefind/darwin-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.5.2.tgz",
+      "integrity": "sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/darwin-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.5.2.tgz",
+      "integrity": "sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/freebsd-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/freebsd-x64/-/freebsd-x64-1.5.2.tgz",
+      "integrity": "sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@pagefind/linux-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.5.2.tgz",
+      "integrity": "sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/linux-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.5.2.tgz",
+      "integrity": "sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/windows-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-arm64/-/windows-arm64-1.5.2.tgz",
+      "integrity": "sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@pagefind/windows-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.5.2.tgz",
+      "integrity": "sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -709,6 +801,24 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pagefind": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.5.2.tgz",
+      "integrity": "sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==",
+      "dev": true,
+      "bin": {
+        "pagefind": "lib/runner/bin.cjs"
+      },
+      "optionalDependencies": {
+        "@pagefind/darwin-arm64": "1.5.2",
+        "@pagefind/darwin-x64": "1.5.2",
+        "@pagefind/freebsd-x64": "1.5.2",
+        "@pagefind/linux-arm64": "1.5.2",
+        "@pagefind/linux-x64": "1.5.2",
+        "@pagefind/windows-arm64": "1.5.2",
+        "@pagefind/windows-x64": "1.5.2"
       }
     },
     "node_modules/path-parse": {

--- a/teachinghistory-website/package.json
+++ b/teachinghistory-website/package.json
@@ -3,12 +3,15 @@
   "private": true,
   "scripts": {
     "dev": "hugo server -D --navigateToChanged",
-    "build": "hugo --minify"
+    "build": "npm run build:hugo && npm run build:search",
+    "build:hugo": "hugo --minify",
+    "build:search": "pagefind --site public"
   },
   "devDependencies": {
-    "tailwindcss": "^3.4",
+    "autoprefixer": "^10.4",
+    "pagefind": "^1.5.2",
     "postcss": "^8.4",
     "postcss-cli": "^11.0",
-    "autoprefixer": "^10.4"
+    "tailwindcss": "^3.4"
   }
 }


### PR DESCRIPTION
## Summary

- add a dedicated `/search/` page using Pagefind's component UI
- index published Hugo content at build time and expose a content-area filter
- exclude navigation, footer, the search page, and the 404 page from search results
- generate the Pagefind bundle in local production builds and the Docker deployment image
- document the completed site-wide search feature

## Why

Issue #3 calls for site-wide search across TeachingHistory.org. Pagefind provides a static, client-side index that fits the existing Hugo architecture without adding a search service or JavaScript framework.

## User impact

Visitors can search articles, teaching materials, historical content, best practices, and digital classroom resources from the primary navigation. Results include excerpts and counts, can be narrowed by content area, support keyboard interaction, and adapt from mobile through desktop layouts.

## Validation

- `just build` — 8,348 Hugo pages built; Pagefind indexed 5,283 pages and 43,137 words
- `just check` — passes with the repository's existing Hugo deprecation, duplicate-taxonomy, and unused-template warnings
- manually tested result rendering, content-area filtering, no-results feedback, reset behavior, and responsive layouts at 375px, 768px, and 1024px

Closes #3
