### PR TITLE
Fix Markdown rendering in card summaries

### DIFF
--- a/teachinghistory-website/layouts/_default/grade-level.html
+++ b/teachinghistory-website/layouts/_default/grade-level.html
@@ -46,7 +46,8 @@
           <p class="font-heading text-xs uppercase tracking-widest mb-3">Teacher's Pick</p>
           <h2 class="font-heading text-3xl leading-tight mb-4 normal-case">{{ $picked.Title }}</h2>
           <p class="font-body text-sm leading-relaxed mb-6">
-            {{ $picked.Params.summary | truncate 200 }}
+            {{ $pickedSummary := $picked.Params.summary | default $picked.Title }}
+            {{ partial "render-inline-markdown.html" (dict "page" $picked "value" $pickedSummary) | plainify | htmlUnescape | truncate 200 }}
           </p>
           {{ partial "arrow-button.html" (dict "text" "Read More" "href" $picked.RelPermalink "color" "black") }}
         </div>

--- a/teachinghistory-website/layouts/index.html
+++ b/teachinghistory-website/layouts/index.html
@@ -49,17 +49,20 @@
             {{ $pool := $candidates | shuffle | first 20 }}
             {{ $items := slice }}
             {{ range $pool }}
+              {{ $summary := .Params.summary | default .Title }}
+              {{ $plainSummary := partial "render-inline-markdown.html" (dict "page" . "value" $summary) | plainify | htmlUnescape | truncate 100 }}
               {{ $items = $items | append (dict
                 "title" .Title
                 "url" .RelPermalink
                 "image" .Params.splash_image
-                "summary" ((.Params.summary | default .Title) | truncate 100)
+                "summary" $plainSummary
               ) }}
             {{ end }}
             {{ $poolData = $poolData | append (dict "items" $items) }}
 
             {{/* Render card with first item as default (works without JS) */}}
             {{ $picked := index $pool 0 }}
+            {{ $pickedSummary := $picked.Params.summary | default $picked.Title }}
 
             <div class="w-40 sm:w-44 lg:w-52 shrink-0 flex flex-col rounded overflow-hidden shadow-md transform {{ $offset }}"
                  data-hero-card>
@@ -77,7 +80,7 @@
               {{/* Section color bar with summary + arrow */}}
               <div class="bg-{{ $color }} px-3 py-3 flex-1 flex flex-col">
                 <p class="font-body text-xs text-white leading-relaxed mb-3 flex-1" data-hero-summary>
-                  {{ $picked.Params.summary | default $picked.Title | truncate 100 }}
+                  {{ partial "render-inline-markdown.html" (dict "page" $picked "value" $pickedSummary) | plainify | htmlUnescape | truncate 100 }}
                 </p>
                 <a href="{{ $picked.RelPermalink }}"
                    class="inline-flex items-center gap-1 text-white text-xs font-semibold"

--- a/teachinghistory-website/layouts/partials/content-card.html
+++ b/teachinghistory-website/layouts/partials/content-card.html
@@ -36,7 +36,7 @@
   <div class="px-3 py-3">
     <p class="font-body text-xs leading-relaxed line-clamp-3 text-gray-600">
       {{ with $page.Params.summary }}
-        {{- . | plainify | truncate 120 -}}
+        {{- partial "render-inline-markdown.html" (dict "page" $page "value" .) | plainify | htmlUnescape | truncate 120 -}}
       {{ else }}
         {{- $page.Summary | plainify | truncate 120 -}}
       {{ end }}

--- a/teachinghistory-website/layouts/partials/subsection-list.html
+++ b/teachinghistory-website/layouts/partials/subsection-list.html
@@ -65,7 +65,7 @@
           <a href="{{ .RelPermalink }}"
              class="listing-card block bg-white rounded shadow border border-gray-light overflow-hidden hover:shadow-md transition group"
              data-title="{{ .Title | lower }}"
-             data-summary="{{ with .Params.summary }}{{ . | plainify | lower }}{{ end }}"
+             data-summary="{{ with .Params.summary }}{{ partial "render-inline-markdown.html" (dict "page" $page "value" .) | plainify | htmlUnescape | lower }}{{ end }}"
              data-keywords="{{ with .Params.keywords }}{{ if reflect.IsSlice . }}{{ delimit . " " | plainify | lower }}{{ else }}{{ . | plainify | lower }}{{ end }}{{ end }}"
              data-grade="{{ with .Params.grade_levels }}{{ delimit . "," }}{{ end }}">
             {{ with $img }}
@@ -85,7 +85,7 @@
             <div class="px-4 pb-4">
               <p class="font-body text-xs leading-relaxed line-clamp-3 text-gray-600">
                 {{ with .Params.summary }}
-                  {{- . | plainify | truncate 160 -}}
+                  {{- partial "render-inline-markdown.html" (dict "page" $page "value" .) | plainify | htmlUnescape | truncate 160 -}}
                 {{ else }}
                   {{- .Summary | plainify | truncate 160 -}}
                 {{ end }}


### PR DESCRIPTION
## Summary

- render Markdown-bearing summaries before converting them to plain card text
- apply the normalization to carousel cards, subsection listing cards, homepage feature cards, and grade-level features
- normalize HTML entities in visible excerpts, listing filter data, and homepage card JSON

## Root cause

Migrated frontmatter summaries can contain inline Markdown links. The shared card templates passed those values directly to Hugo's `plainify` function, which strips HTML but does not parse Markdown. As a result, visitors saw literal strings such as `[video](https://...)` in card excerpts.

## User impact

Card excerpts now show readable linked text without exposing URLs. The cards remain single valid links, avoiding nested anchors, and the corresponding client-side filter data receives the same normalized prose.

## Validation

- `just build` — 8,348 Hugo pages built; Pagefind indexed 5,283 pages
- `just check` — passes with the repository's existing Hugo warnings
- visually verified the reported Digital Classroom carousel and representative Markdown-bearing summaries
- verified subsection filter attributes contain normalized punctuation and no encoded HTML entities
- verified homepage feature summaries and affected generated pages contain no literal Markdown-link syntax

Refs #21
